### PR TITLE
Experiment/json mqtt firmware plugin

### DIFF
--- a/crates/extensions/c8y_firmware_manager/src/actor.rs
+++ b/crates/extensions/c8y_firmware_manager/src/actor.rs
@@ -1,15 +1,8 @@
 use async_trait::async_trait;
-use c8y_api::smartrest::message::collect_smartrest_messages;
-use c8y_api::smartrest::message::get_smartrest_template_id;
-use c8y_api::smartrest::smartrest_deserializer::SmartRestFirmwareRequest;
-use c8y_api::smartrest::smartrest_deserializer::SmartRestRequestGeneric;
-use c8y_api::smartrest::smartrest_serializer::TryIntoOperationStatusMessage;
-use c8y_api::smartrest::topic::C8yTopic;
 use c8y_http_proxy::credentials::JwtRetriever;
 use log::error;
 use log::info;
 use log::warn;
-use nanoid::nanoid;
 use sha256::digest;
 use sha256::try_digest;
 use std::collections::HashMap;
@@ -40,7 +33,9 @@ use tedge_utils::file::PermissionEntry;
 
 use crate::config::FirmwareManagerConfig;
 use crate::error::FirmwareManagementError;
-use crate::message::DownloadFirmwareStatusMessage;
+use crate::json::FirmwareInfo;
+use crate::json::NewFirmwareRequest;
+use crate::json::OperationPayload;
 use crate::message::FirmwareOperationRequest;
 use crate::message::FirmwareOperationResponse;
 use crate::operation::ActiveOperationState;
@@ -50,8 +45,9 @@ use crate::operation::OperationKey;
 pub type OperationSetTimeout = SetTimeout<OperationKey>;
 pub type OperationTimeout = Timeout<OperationKey>;
 
-pub type IdDownloadResult = (String, DownloadResult);
-pub type IdDownloadRequest = (String, DownloadRequest);
+pub type OperationId = String;
+pub type IdDownloadResult = (OperationId, DownloadResult);
+pub type IdDownloadRequest = (OperationId, DownloadRequest);
 
 fan_in_message_type!(FirmwareInput[MqttMessage, OperationTimeout, IdDownloadResult] : Debug);
 fan_in_message_type!(FirmwareOutput[MqttMessage, OperationSetTimeout, IdDownloadRequest] : Debug);
@@ -59,7 +55,7 @@ fan_in_message_type!(FirmwareOutput[MqttMessage, OperationSetTimeout, IdDownload
 pub struct FirmwareManagerActor {
     config: FirmwareManagerConfig,
     active_child_ops: HashMap<OperationKey, ActiveOperationState>,
-    reqs_pending_download: HashMap<String, SmartRestFirmwareRequest>,
+    reqs_pending_download: HashMap<String, NewFirmwareRequest>,
     message_box: FirmwareManagerMessageBox,
 }
 
@@ -69,16 +65,8 @@ impl Actor for FirmwareManagerActor {
         "FirmwareManager"
     }
 
-    // This actor handles 3 kinds of messages from its peer actors:
-    //
-    // 1. MQTT messages from the MqttActor for firmware update requests from the cloud and firmware update responses from the child devices
-    // 2. Operation timeouts from the TimerActor for requests for which the child devices don't respond within the timeout window
-    // 3. Download results from the DownloaderActor for firmware download requests
-
     async fn run(&mut self) -> Result<(), RuntimeError> {
         self.resend_operations_to_child_device().await?;
-        // TODO: We need a dedicated actor to publish 500 later.
-        self.get_pending_operations_from_cloud().await?;
 
         info!("Ready to serve firmware requests.");
         while let Some(event) = self.message_box.recv().await {
@@ -114,11 +102,9 @@ impl FirmwareManagerActor {
         message: MqttMessage,
     ) -> Result<(), FirmwareManagementError> {
         if self.config.c8y_request_topics.accept(&message) {
-            // New firmware operation from c8y
-            self.handle_firmware_update_smartrest_request(message)
-                .await?;
+            // "firmware/update" topic
+            self.handle_firmware_update_json_request(message).await;
         } else if self.config.firmware_update_response_topics.accept(&message) {
-            // Response from child device
             self.handle_child_device_firmware_operation_response(message.clone())
                 .await?;
         } else {
@@ -130,101 +116,77 @@ impl FirmwareManagerActor {
         Ok(())
     }
 
-    // This is the start point function when receiving a new c8y_Firmware operation from c8y.
-    pub async fn handle_firmware_update_smartrest_request(
-        &mut self,
-        message: MqttMessage,
-    ) -> Result<(), FirmwareManagementError> {
-        for smartrest_message in collect_smartrest_messages(message.payload_str()?) {
-            let result = match get_smartrest_template_id(&smartrest_message).as_str() {
-                "515" => match SmartRestFirmwareRequest::from_smartrest(&smartrest_message) {
-                    Ok(firmware_request) => {
-                        // Addressing a new firmware operation to further step.
-                        self.handle_firmware_download_request(firmware_request)
-                            .await
+    pub async fn handle_firmware_update_json_request(&mut self, message: MqttMessage) {
+        match NewFirmwareRequest::try_from(message.clone()) {
+            Ok(request) => {
+                match self.handle_firmware_download_request(request).await {
+                    Ok(_) => {
+                        // Successfully created a new download request
                     }
-                    Err(_) => {
-                        error!("Incorrect c8y_Firmware SmartREST payload: {smartrest_message}");
-                        Ok(())
+                    Err(err) => {
+                        error!("Handling of operation: '{message:?}' failed with {err}");
                     }
-                },
-                _ => {
-                    // Ignore operation messages not meant for this plugin
-                    Ok(())
                 }
-            };
-
-            if let Err(err) = result {
-                error!("Handling of operation: '{smartrest_message}' failed with {err}");
+            }
+            Err(_) => {
+                error!("Incorrect Firmware Request payload: {message:?}");
             }
         }
-        Ok(())
     }
 
-    // Validates the received SmartREST request and processes it further if it's meant for a child device
     async fn handle_firmware_download_request(
         &mut self,
-        smartrest_request: SmartRestFirmwareRequest,
+        request: NewFirmwareRequest,
     ) -> Result<(), FirmwareManagementError> {
-        info!("Handling c8y_Firmware operation: {smartrest_request}");
+        info!("Handling c8y_Firmware operation: {request:?}");
 
-        if smartrest_request.device == self.config.tedge_device_id {
+        if request.device == self.config.tedge_device_id {
             warn!("c8y-firmware-plugin does not support firmware operation for the main tedge device. \
             Please define a custom operation handler for the c8y_Firmware operation.");
             return Ok(());
         }
 
-        let child_id = smartrest_request.device.as_str();
+        let child_id = request.device.as_str();
+        let op_id = request.id.as_str();
 
-        if let Err(err) = self
-            .validate_same_request_in_progress(smartrest_request.clone())
-            .await
-        {
+        if let Err(err) = self.validate_same_request_in_progress(op_id).await {
             return match err {
                 FirmwareManagementError::RequestAlreadyAddressed => {
                     warn!("Skip the received c8y_Firmware operation as the same operation is already in progress.");
                     Ok(())
                 }
                 _ => {
-                    self.fail_operation_in_cloud(child_id, None, &err.to_string())
+                    self.fail_operation_in_cloud(child_id, op_id, &err.to_string())
                         .await?;
                     Err(err)
                 }
             };
         }
 
-        let op_id = nanoid!();
-        if let Err(err) =
-            // Addressing the new firmware operation to further step.
-            self
-                .handle_firmware_download_request_child_device(
-                    smartrest_request.clone(),
-                    op_id.as_str(),
-                )
-                .await
+        match self
+            .handle_firmware_download_request_child_device(request.clone())
+            .await
         {
-            self.fail_operation_in_cloud(child_id, Some(&op_id), &err.to_string())
-                .await?;
+            Ok(_) => Ok(()),
+            Err(err) => {
+                self.fail_operation_in_cloud(child_id, op_id, &err.to_string())
+                    .await
+            }
         }
-
-        Ok(())
     }
 
-    // Check if the firmware file is already in cache.
-    // If yes, publish a firmware request to child device with that firmware in the cache.
-    // Otherwise, send a download request to the DownloaderActor and return immediately without waiting for the download to complete so that other requests/responses can be processed while the download is in progress.
-    // The download will be performed by the DownloaderActor asynchronously and the response will be processed by this actor later on, in the `run` method.
     async fn handle_firmware_download_request_child_device(
         &mut self,
-        smartrest_request: SmartRestFirmwareRequest,
-        operation_id: &str,
+        request: NewFirmwareRequest,
     ) -> Result<(), FirmwareManagementError> {
-        let firmware_url = smartrest_request.url.as_str();
+        let firmware_url = request.firmware.url.as_str();
         let file_cache_key = digest(firmware_url);
         let cache_file_path = self
             .config
             .validate_and_get_cache_dir_path()?
             .join(&file_cache_key);
+
+        let operation_id = request.id.as_str();
 
         if cache_file_path.is_file() {
             info!(
@@ -232,17 +194,10 @@ impl FirmwareManagerActor {
                 cache_file_path.display()
             );
             // Publish a firmware update request to child device.
-            self.handle_firmware_update_request_with_downloaded_file(
-                smartrest_request,
-                operation_id,
-                &cache_file_path,
-            )
-            .await?;
+            self.handle_firmware_update_request_with_downloaded_file(request, &cache_file_path)
+                .await?;
         } else {
-            info!(
-                "Awaiting firmware download for op_id: {} from url: {}",
-                operation_id, firmware_url
-            );
+            info!("Awaiting firmware download for op_id: {operation_id} from url: {firmware_url}");
 
             let auth = if self
                 .config
@@ -266,7 +221,7 @@ impl FirmwareManagerActor {
                 .send((operation_id.to_string(), download_request))
                 .await?;
             self.reqs_pending_download
-                .insert(operation_id.to_string(), smartrest_request);
+                .insert(operation_id.to_string(), request);
         }
         Ok(())
     }
@@ -279,50 +234,48 @@ impl FirmwareManagerActor {
         operation_id: &str,
         download_result: DownloadResult,
     ) -> Result<(), FirmwareManagementError> {
-        if let Some(smartrest_request) = self.reqs_pending_download.remove(operation_id) {
-            let child_id = smartrest_request.device.clone();
+        if let Some(request) = self.reqs_pending_download.remove(operation_id) {
+            let child_id = request.device.clone();
+
             match download_result {
                 Ok(response) => {
-                    if let Err(err) =
-                        // Publish a firmware update request to child device.
-                        self
-                            .handle_firmware_update_request_with_downloaded_file(
-                                smartrest_request,
-                                operation_id,
-                                &response.file_path,
-                            )
-                            .await
-                    {
-                        self.fail_operation_in_cloud(
-                            &child_id,
-                            Some(operation_id),
-                            &err.to_string(),
+                    match self
+                        .handle_firmware_update_request_with_downloaded_file(
+                            request,
+                            &response.file_path,
                         )
-                        .await?;
+                        .await
+                    {
+                        Ok(_) => {} // Firmware upload request is sent to child device successfully
+                        Err(err) => {
+                            self.fail_operation_in_cloud(&child_id, operation_id, &err.to_string())
+                                .await?;
+                        }
                     }
                 }
                 Err(err) => {
-                    let firmware_url = smartrest_request.url;
+                    let firmware_url = request.firmware.url;
                     let failure_reason = format!("Download from {firmware_url} failed with {err}");
-                    self.fail_operation_in_cloud(&child_id, Some(operation_id), &failure_reason)
+                    self.fail_operation_in_cloud(&child_id, operation_id, &failure_reason)
                         .await?;
                 }
             }
         } else {
             error!("Unexpected: Download completed for unknown operation: {operation_id}");
         }
+
         Ok(())
     }
 
     // Publish a firmware update request to the child device with firmware file path in the cache published via the file-transfer service and start the timer
     async fn handle_firmware_update_request_with_downloaded_file(
         &mut self,
-        smartrest_request: SmartRestFirmwareRequest,
-        operation_id: &str,
+        request: NewFirmwareRequest,
         downloaded_firmware: &Path,
     ) -> Result<(), FirmwareManagementError> {
-        let child_id = smartrest_request.device.as_str();
-        let firmware_url = smartrest_request.url.as_str();
+        let op_id = request.id.as_str();
+        let child_id = request.device.as_str();
+        let firmware_url = request.firmware.url.as_str();
         let file_cache_key = digest(firmware_url);
         let cache_dir_path = self.config.validate_and_get_cache_dir_path()?;
         let cache_file_path = cache_dir_path.join(&file_cache_key);
@@ -332,7 +285,7 @@ impl FirmwareManagerActor {
             move_file(
                 &downloaded_firmware,
                 &cache_file_path,
-                PermissionEntry::new(None, None, None),
+                PermissionEntry::default(),
             )
             .await?;
         }
@@ -346,10 +299,10 @@ impl FirmwareManagerActor {
         let file_sha256 = try_digest(symlink_path.as_path())?;
 
         let operation_entry = FirmwareOperationEntry {
-            operation_id: operation_id.to_string(),
+            operation_id: op_id.to_string(),
             child_id: child_id.to_string(),
-            name: smartrest_request.name.to_string(),
-            version: smartrest_request.version.to_string(),
+            name: request.firmware.name.to_string(),
+            version: request.firmware.version.to_string(),
             server_url: firmware_url.to_string(),
             file_transfer_url: file_transfer_url.clone(),
             sha256: file_sha256.to_string(),
@@ -361,7 +314,7 @@ impl FirmwareManagerActor {
         self.publish_firmware_update_request(operation_entry)
             .await?;
 
-        let operation_key = OperationKey::new(child_id, operation_id);
+        let operation_key = OperationKey::new(child_id, op_id);
         self.active_child_ops
             .insert(operation_key.clone(), ActiveOperationState::Pending);
 
@@ -396,7 +349,7 @@ impl FirmwareManagerActor {
                 {
                     self.fail_operation_in_cloud(
                         &child_id,
-                        Some(response.get_payload().operation_id.as_str()),
+                        response.get_payload().operation_id.as_str(),
                         &err.to_string(),
                     )
                     .await?;
@@ -426,7 +379,8 @@ impl FirmwareManagerActor {
         match current_operation_state {
             Some(&ActiveOperationState::Executing) => {}
             Some(&ActiveOperationState::Pending) => {
-                self.publish_c8y_executing_message(&child_id).await?;
+                self.publish_operation_executing_message(operation_id, &child_id)
+                    .await?;
                 self.active_child_ops
                     .insert(operation_key.clone(), ActiveOperationState::Executing);
             }
@@ -442,15 +396,17 @@ impl FirmwareManagerActor {
                 let operation_entry =
                     FirmwareOperationEntry::read_from_file(status_file_path.as_path())?;
 
-                self.publish_c8y_installed_firmware_message(&operation_entry)
+                self.publish_installed_firmware_info(&operation_entry)
                     .await?;
-                self.publish_c8y_successful_message(&child_id).await?;
+                self.publish_operation_successful_message(operation_id, &child_id)
+                    .await?;
 
                 self.remove_status_file(operation_id)?;
                 self.remove_entry_from_active_operations(&operation_key);
             }
             OperationStatus::Failed => {
-                self.publish_c8y_failed_message(
+                self.publish_operation_failed_message(
+                    operation_id,
                     &child_id,
                     "No failure reason provided by child device.",
                 )
@@ -484,7 +440,7 @@ impl FirmwareManagerActor {
         {
             self.fail_operation_in_cloud(
                 &child_id,
-                Some(&operation_id),
+                &operation_id,
                 &format!("Child device {child_id} did not respond within the timeout interval of {}sec. Operation ID={operation_id}", self.config.timeout_sec.as_secs()),
             ).await
         } else {
@@ -493,10 +449,9 @@ impl FirmwareManagerActor {
         }
     }
 
-    // This function can be removed once we start using operation ID from c8y.
     async fn validate_same_request_in_progress(
         &mut self,
-        smartrest_request: SmartRestFirmwareRequest,
+        op_id: &str,
     ) -> Result<(), FirmwareManagementError> {
         let firmware_dir_path = self.config.validate_and_get_firmware_dir_path()?;
 
@@ -504,11 +459,7 @@ impl FirmwareManagerActor {
             match entry {
                 Ok(file_path) => match FirmwareOperationEntry::read_from_file(&file_path.path()) {
                     Ok(recorded_entry) => {
-                        if recorded_entry.child_id == smartrest_request.device
-                            && recorded_entry.name == smartrest_request.name
-                            && recorded_entry.version == smartrest_request.version
-                            && recorded_entry.server_url == smartrest_request.url
-                        {
+                        if recorded_entry.operation_id == op_id {
                             info!("The same operation as the received c8y_Firmware operation is already in progress.");
 
                             // Resend a firmware request with incremented attempt.
@@ -521,9 +472,11 @@ impl FirmwareManagerActor {
                             new_operation_entry.overwrite_file(&firmware_dir_path)?;
                             self.publish_firmware_update_request(new_operation_entry)
                                 .await?;
+
                             // Add operation to hashmap
                             self.active_child_ops
                                 .insert(operation_key.clone(), ActiveOperationState::Pending);
+
                             // Start timer
                             self.message_box
                                 .timer_sender
@@ -554,21 +507,19 @@ impl FirmwareManagerActor {
     async fn fail_operation_in_cloud(
         &mut self,
         child_id: &str,
-        op_id: Option<&str>,
+        operation_id: &str,
         failure_reason: &str,
     ) -> Result<(), FirmwareManagementError> {
         error!("{}", failure_reason);
-        let op_state = if let Some(operation_id) = op_id {
-            self.remove_status_file(operation_id)?;
-            self.remove_entry_from_active_operations(&OperationKey::new(child_id, operation_id))
-        } else {
-            ActiveOperationState::Pending
-        };
+        self.remove_status_file(operation_id)?;
+        let op_state =
+            self.remove_entry_from_active_operations(&OperationKey::new(child_id, operation_id));
 
         if op_state == ActiveOperationState::Pending {
-            self.publish_c8y_executing_message(child_id).await?;
+            self.publish_operation_executing_message(operation_id, child_id)
+                .await?;
         }
-        self.publish_c8y_failed_message(child_id, failure_reason)
+        self.publish_operation_failed_message(operation_id, child_id, failure_reason)
             .await?;
 
         Ok(())
@@ -592,9 +543,11 @@ impl FirmwareManagerActor {
                 operation_entry.overwrite_file(&firmware_dir_path)?;
                 self.publish_firmware_update_request(operation_entry)
                     .await?;
+
                 // Add operation to hashmap
                 self.active_child_ops
                     .insert(operation_key.clone(), ActiveOperationState::Pending);
+
                 // Start timer
                 self.message_box
                     .timer_sender
@@ -630,65 +583,59 @@ impl FirmwareManagerActor {
         Ok(())
     }
 
-    async fn publish_c8y_executing_message(
+    async fn publish_operation_executing_message(
         &mut self,
-        child_id: &str,
+        op_id: &str,
+        device_name: &str,
     ) -> Result<(), FirmwareManagementError> {
-        let c8y_child_topic = Topic::new_unchecked(
-            &C8yTopic::ChildSmartRestResponse(child_id.to_string()).to_string(),
-        );
-        let executing_msg = MqttMessage::new(
-            &c8y_child_topic,
-            DownloadFirmwareStatusMessage::status_executing()?,
-        );
+        let topic = Topic::new_unchecked("operation/status");
+        let payload = OperationPayload::new(op_id, device_name, OperationStatus::Executing);
+        let executing_msg = MqttMessage::new(&topic, payload.to_string());
+
         self.message_box.mqtt_publisher.send(executing_msg).await?;
         Ok(())
     }
 
-    async fn publish_c8y_successful_message(
+    async fn publish_operation_successful_message(
         &mut self,
-        child_id: &str,
+        op_id: &str,
+        device_name: &str,
     ) -> Result<(), FirmwareManagementError> {
-        let c8y_child_topic = Topic::new_unchecked(
-            &C8yTopic::ChildSmartRestResponse(child_id.to_string()).to_string(),
-        );
-        let successful_msg = MqttMessage::new(
-            &c8y_child_topic,
-            DownloadFirmwareStatusMessage::status_successful(None)?,
-        );
+        let topic = Topic::new_unchecked("operation/status");
+        let payload = OperationPayload::new(op_id, device_name, OperationStatus::Successful);
+        let successful_msg = MqttMessage::new(&topic, payload.to_string());
+
         self.message_box.mqtt_publisher.send(successful_msg).await?;
         Ok(())
     }
 
-    async fn publish_c8y_failed_message(
+    async fn publish_operation_failed_message(
         &mut self,
-        child_id: &str,
+        op_id: &str,
+        device_name: &str,
         failure_reason: &str,
     ) -> Result<(), FirmwareManagementError> {
-        let c8y_child_topic = Topic::new_unchecked(
-            &C8yTopic::ChildSmartRestResponse(child_id.to_string()).to_string(),
-        );
-        let failed_msg = MqttMessage::new(
-            &c8y_child_topic,
-            DownloadFirmwareStatusMessage::status_failed(failure_reason.to_string())?,
-        );
+        let topic = Topic::new_unchecked("operation/status");
+        let payload = OperationPayload::new(op_id, device_name, OperationStatus::Failed)
+            .with_reason(failure_reason);
+        let failed_msg = MqttMessage::new(&topic, payload.to_string());
+
         self.message_box.mqtt_publisher.send(failed_msg).await?;
         Ok(())
     }
 
-    async fn publish_c8y_installed_firmware_message(
+    async fn publish_installed_firmware_info(
         &mut self,
         operation_entry: &FirmwareOperationEntry,
     ) -> Result<(), FirmwareManagementError> {
-        let c8y_child_topic = Topic::new_unchecked(
-            &C8yTopic::ChildSmartRestResponse(operation_entry.child_id.clone()).to_string(),
+        let topic = Topic::new_unchecked("firmware/data");
+        let firmware_info = FirmwareInfo::new(
+            &operation_entry.name,
+            &operation_entry.server_url,
+            &operation_entry.version,
         );
-        let installed_firmware_payload = format!(
-            "115,{},{},{}",
-            operation_entry.name, operation_entry.version, operation_entry.server_url
-        );
-        let installed_firmware_message =
-            MqttMessage::new(&c8y_child_topic, installed_firmware_payload);
+        let installed_firmware_message = MqttMessage::new(&topic, firmware_info.to_string());
+
         self.message_box
             .mqtt_publisher
             .send(installed_firmware_message)
@@ -726,13 +673,6 @@ impl FirmwareManagerActor {
             unix_fs::symlink(original_file_path, &symlink_path)?;
         }
         Ok(symlink_path)
-    }
-
-    // Candidate to be removed since another actor should be in charge of this.
-    async fn get_pending_operations_from_cloud(&mut self) -> Result<(), FirmwareManagementError> {
-        let message = MqttMessage::new(&C8yTopic::SmartRestResponse.to_topic()?, "500");
-        self.message_box.mqtt_publisher.send(message).await?;
-        Ok(())
     }
 }
 

--- a/crates/extensions/c8y_firmware_manager/src/actor.rs
+++ b/crates/extensions/c8y_firmware_manager/src/actor.rs
@@ -494,6 +494,7 @@ impl FirmwareManagerActor {
 
         let payload = OperationStatusPayload::new(
             operation_id,
+            OperationStatus::Failed,
             &entry.child_id,
             &entry.name,
             &entry.server_url,
@@ -521,6 +522,7 @@ impl FirmwareManagerActor {
         ));
         let payload = OperationStatusPayload::new(
             &entry.operation_id,
+            OperationStatus::Executing,
             &entry.child_id,
             &entry.name,
             &entry.server_url,
@@ -544,6 +546,7 @@ impl FirmwareManagerActor {
         ));
         let payload = OperationStatusPayload::new(
             &entry.operation_id,
+            OperationStatus::Successful,
             &entry.child_id,
             &entry.name,
             &entry.server_url,

--- a/crates/extensions/c8y_firmware_manager/src/config.rs
+++ b/crates/extensions/c8y_firmware_manager/src/config.rs
@@ -1,7 +1,6 @@
 use crate::error::FirmwareManagementError;
 
 use c8y_api::http_proxy::C8yEndPoint;
-use c8y_api::smartrest::topic::C8yTopic;
 use log::info;
 use std::path::Path;
 use std::path::PathBuf;
@@ -57,7 +56,7 @@ impl FirmwareManagerConfig {
         let file_transfer_dir = data_dir.join("file-transfer");
         let firmware_dir = data_dir.join("firmware");
 
-        let c8y_request_topics = C8yTopic::SmartRestRequest.into();
+        let c8y_request_topics = TopicFilter::new_unchecked("firmware/update");
         let health_check_topics = health_check_topics(PLUGIN_SERVICE_NAME);
         let firmware_update_response_topics =
             TopicFilter::new_unchecked(FIRMWARE_UPDATE_RESPONSE_TOPICS);

--- a/crates/extensions/c8y_firmware_manager/src/error.rs
+++ b/crates/extensions/c8y_firmware_manager/src/error.rs
@@ -19,6 +19,10 @@ pub enum DirectoryError {
 
     #[error(transparent)]
     FromFileError(#[from] tedge_utils::file::FileError),
+
+    // Consider to improve
+    #[error("The given sha256 is mismatched with downloaded file")]
+    MismatchedSha256,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/extensions/c8y_firmware_manager/src/error.rs
+++ b/crates/extensions/c8y_firmware_manager/src/error.rs
@@ -1,60 +1,43 @@
-use tedge_actors::RuntimeError;
-
 #[derive(thiserror::Error, Debug)]
-pub enum FirmwareManagementError {
-    #[error("Invalid topic received from child device: {topic}")]
-    InvalidTopicFromChildOperation { topic: String },
-
-    #[error("Failed to copy a file from {src} to {dest}")]
-    FileCopyFailed {
-        src: std::path::PathBuf,
-        dest: std::path::PathBuf,
-    },
-
+pub enum DirNotFound {
     #[error(
         "Directory {path} is not found. Run 'c8y-firmware-plugin --init' to create the directory."
     )]
     DirectoryNotFound { path: std::path::PathBuf },
+}
 
-    #[error("The received SmartREST request is duplicated with already addressed operation. Ignore this request.")]
-    RequestAlreadyAddressed,
-
-    #[error("Failed to retrieve JWT token.")]
-    NoJwtToken,
+#[derive(thiserror::Error, Debug)]
+pub enum DirectoryError {
+    #[error(transparent)]
+    FromIoError(#[from] std::io::Error),
 
     #[error("Failed to parse response from child device with: {0}")]
     FromSerdeJsonError(#[from] serde_json::Error),
 
     #[error(transparent)]
-    FromSmartRestSerializerError(#[from] c8y_api::smartrest::error::SmartRestSerializerError),
-
-    #[error(transparent)]
-    FromIoError(#[from] std::io::Error),
+    FromDirNotFound(#[from] DirNotFound),
 
     #[error(transparent)]
     FromFileError(#[from] tedge_utils::file::FileError),
+}
 
-    #[error(transparent)]
-    FromSMCumulocityMapperError(#[from] c8y_api::smartrest::error::SMCumulocityMapperError),
-
-    #[error(transparent)]
-    FromSystemServiceError(#[from] tedge_config::system_services::SystemServiceError),
-
-    #[error(transparent)]
-    FromTEdgeConfigError(#[from] tedge_config::TEdgeConfigError),
-
-    #[error(transparent)]
-    FromConfigSettingError(#[from] tedge_config::ConfigSettingError),
+#[derive(thiserror::Error, Debug)]
+pub enum JwtRetrievalError {
+    #[error("Failed to retrieve JWT token.")]
+    NoJwtToken,
 
     #[error(transparent)]
     FromChannelError(#[from] tedge_actors::ChannelError),
-
-    #[error(transparent)]
-    FromMqttError(#[from] tedge_mqtt_ext::MqttError),
 }
 
-impl From<FirmwareManagementError> for RuntimeError {
-    fn from(error: FirmwareManagementError) -> Self {
-        RuntimeError::ActorError(Box::new(error))
-    }
+#[derive(thiserror::Error, Debug)]
+pub enum FirmwareRequestResponseError {
+    #[error(transparent)]
+    FromMqttError(#[from] tedge_mqtt_ext::MqttError),
+
+    #[error("Invalid topic received from child device: {topic}")]
+    InvalidTopicFromChildOperation { topic: String },
+
+    #[error("Failed to parse response from child device with: {0}")]
+    FromSerdeJsonError(#[from] serde_json::Error),
 }

--- a/crates/extensions/c8y_firmware_manager/src/json.rs
+++ b/crates/extensions/c8y_firmware_manager/src/json.rs
@@ -92,6 +92,16 @@ impl OperationStatusPayload {
             ..self
         }
     }
+
+    pub fn from_firmware_request(request: &NewFirmwareRequest, status: OperationStatus) -> Self {
+        Self {
+            id: request.id.clone(),
+            status,
+            device: request.device.clone(),
+            firmware: request.firmware.clone(),
+            reason: None,
+        }
+    }
 }
 
 impl ToString for OperationStatusPayload {

--- a/crates/extensions/c8y_firmware_manager/src/json.rs
+++ b/crates/extensions/c8y_firmware_manager/src/json.rs
@@ -1,0 +1,119 @@
+use crate::error::FirmwareRequestResponseError;
+use serde::Deserialize;
+use serde::Serialize;
+use tedge_mqtt_ext::MqttMessage;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FirmwareInfo {
+    pub name: String,
+    pub url: String,
+    pub version: String,
+}
+
+impl FirmwareInfo {
+    pub fn new(name: &str, url: &str, version: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            url: url.to_string(),
+            version: version.to_string(),
+        }
+    }
+}
+
+impl ToString for FirmwareInfo {
+    fn to_string(&self) -> String {
+        serde_json::to_string(&self).expect("infallible")
+    }
+}
+
+// Candidate to be generic later.
+#[derive(Deserialize, Debug, Clone)]
+pub struct NewFirmwareRequest {
+    pub id: String,
+    pub device: String,
+    #[serde(flatten)]
+    pub firmware: FirmwareInfo,
+}
+
+impl TryFrom<MqttMessage> for NewFirmwareRequest {
+    type Error = FirmwareRequestResponseError;
+
+    fn try_from(value: MqttMessage) -> Result<Self, Self::Error> {
+        let payload = value.payload.as_str()?;
+        let request: NewFirmwareRequest = serde_json::from_str(payload)?;
+        Ok(request)
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct OperationStatusPayload {
+    pub id: String,
+    pub device: String,
+    #[serde(flatten)]
+    pub firmware: FirmwareInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl OperationStatusPayload {
+    pub fn new(id: &str, device: &str, name: &str, url: &str, version: &str) -> Self {
+        Self {
+            id: id.into(),
+            device: device.to_string(),
+            firmware: FirmwareInfo::new(name, url, version),
+            reason: None,
+        }
+    }
+
+    pub fn with_reason(self, reason: &str) -> Self {
+        Self {
+            reason: Some(reason.into()),
+            ..self
+        }
+    }
+}
+
+impl ToString for OperationStatusPayload {
+    fn to_string(&self) -> String {
+        serde_json::to_string(&self).expect("infallible")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use assert_json_diff::assert_json_eq;
+    use assert_matches::assert_matches;
+    use serde_json::json;
+
+    #[test]
+    fn serialize_operation_payload() {
+        let operation = OperationStatusPayload::new("id", "device", "name", "url", "version");
+        let json = serde_json::to_string(&operation).unwrap();
+        dbg!(&json);
+    }
+
+    #[test]
+    fn serialize_operation_payload_with_reason() {
+        let operation = OperationStatusPayload::new("id", "device", "name", "url", "version")
+            .with_reason("aaa");
+        let json = operation.to_string();
+        dbg!(&json);
+    }
+
+    #[test]
+    fn deserialize_firmware_request() {
+        let data = r#"
+{
+    "id": "50203",
+    "name": "simple text",
+    "version": "2.0",
+    "url": "https://t6352.basic.stage.c8y.io/inventory/binaries/11203",
+    "device": "87aa0422-ccb0-4435-a497-117b2f00ea67"
+}"#;
+        let value: NewFirmwareRequest = serde_json::from_str(data).unwrap();
+
+        dbg!(&value);
+    }
+}

--- a/crates/extensions/c8y_firmware_manager/src/lib.rs
+++ b/crates/extensions/c8y_firmware_manager/src/lib.rs
@@ -1,8 +1,10 @@
 mod actor;
 mod config;
 mod error;
+mod json;
 mod message;
 mod operation;
+
 #[cfg(test)]
 mod tests;
 
@@ -76,7 +78,7 @@ impl FirmwareManagerBuilder {
     }
 
     pub fn subscriptions() -> TopicFilter {
-        vec!["c8y/s/ds", "tedge/+/commands/res/firmware_update"]
+        vec!["firmware/update", "tedge/+/commands/res/firmware_update"]
             .try_into()
             .expect("Infallible")
     }

--- a/crates/extensions/c8y_firmware_manager/src/lib.rs
+++ b/crates/extensions/c8y_firmware_manager/src/lib.rs
@@ -78,9 +78,12 @@ impl FirmwareManagerBuilder {
     }
 
     pub fn subscriptions() -> TopicFilter {
-        vec!["firmware/update", "tedge/+/commands/res/firmware_update"]
-            .try_into()
-            .expect("Infallible")
+        vec![
+            "tedge/+/commands/firmware_update/start",
+            "tedge/+/commands/res/firmware_update",
+        ]
+        .try_into()
+        .expect("Infallible")
     }
 }
 

--- a/crates/extensions/c8y_firmware_manager/src/message.rs
+++ b/crates/extensions/c8y_firmware_manager/src/message.rs
@@ -252,7 +252,7 @@ mod tests {
         let result = FirmwareOperationResponse::try_from(&message);
         assert_matches!(
             result.unwrap_err(),
-            FirmwareManagementError::FromSerdeJsonError { .. }
+            FirmwareRequestResponseError::FromSerdeJsonError { .. }
         );
     }
 
@@ -270,7 +270,7 @@ mod tests {
         let result = FirmwareOperationResponse::try_from(&message);
         assert_matches!(
             result.unwrap_err(),
-            FirmwareManagementError::FromSerdeJsonError { .. }
+            FirmwareRequestResponseError::FromSerdeJsonError { .. }
         );
     }
 
@@ -288,7 +288,7 @@ mod tests {
         let result = FirmwareOperationResponse::try_from(&message);
         assert_matches!(
             result.unwrap_err(),
-            FirmwareManagementError::FromSerdeJsonError { .. }
+            FirmwareRequestResponseError::FromSerdeJsonError { .. }
         );
     }
 
@@ -306,7 +306,7 @@ mod tests {
         let result = FirmwareOperationResponse::try_from(&message);
         assert_matches!(
             result.unwrap_err(),
-            FirmwareManagementError::FromSerdeJsonError { .. }
+            FirmwareRequestResponseError::FromSerdeJsonError { .. }
         );
     }
 }


### PR DESCRIPTION
# Cloud Agnostic Firmware Plugin
For Thin Edge Experiment Week 22.05.2023-26.05.2023

What includes:
* Cloud agnostic request input and output
* Code refactoring for better error handling 

## Current problems
* Without operation ID coming from c8y is potentially fragile to address operation state. We cannot address all corner cases.
* How can we distinguish
a. the same operation with the same ID is sent to plugin twice or more (by 500 or re-connection)
b. the same operation but with different ID is sent to plugin.
* https://github.com/thin-edge/thin-edge.io/pull/1830#discussion_r1150075283

## Motivation
* We need operation ID from c8y and use it for sending operation status update!
* Plus, as long as we can get an operation ID and send operation status update by ID-based, the format of input and output doesn't matter. => Cloud agnostic request input and response output!
* Also, I want to see how much complexity in the code can be removed. => Refactoring!
* Furthermore, I got influenced by Marcel's error handling talk in Rust-Ramp-up. => Error refactoring!

## Takeaway
### Operation ID based cloud agnostic implementation
* The same design pattern as software management (combination mapper and plugin) works.
* C8y accepts SUCCESSFUL/FAILED message without EXECUTING.
* Neither JSON over MQTT nor custom SmartREST supports operation status update using operation ID. => HTTP REST is the only option as of now.

### Refactoring
* Returning specific error type helps to understand when the actor must stop and which error the actor ignores.
* Returning enum is very practical when multiple condition is needed. (e.g. `RequestKind::New`, `RequestKind::AlreadyAddressed` and Err)
https://github.com/rina23q/thin-edge.io/blob/experiment/json-mqtt-firmware-plugin/crates/extensions/c8y_firmware_manager/src/actor.rs#L152

### Leftover
* The plugin creates `DownloadInfo`, which requires JWT token when the download URL is c8y tenant. So, the code is not 100% cloud-agnostic yet.

---

## How to try end-to-end firmware operation with Cumulocity?
Use and run https://github.com/reubenmiller/tedge-mapper-template

## New contract
### Operation input from outside
Topic: `tedge/child01/commands/firmware_update/start`
```json
{
    "id": "1234",
    "device": "child01",
    "name": "firmware",
    "version": "0.1.0",
    "url": "http://abc.com",
    "sha256": "abcdefgh"
}
```
* `sha256` is optional. If not necessary, omit the field completely or `"sha256": null`.

### Request to child device (no change)
Topic: `tedge/child01/commands/req/firmware_update`
```json
{
    "id": "1234",
    "attempt": 1,
    "name": "firmware",
    "version": "0.1.0",
    "sha256": "e60d891f75e56177b7a4d375a65f2216c5dce4ee9c57468599fcdc2aaf446459",
    "url": "http://127.0.0.1:8000/tedge/file-transfer/child01/firmware_update/c1ca9231d75029c10c8826a89277c99fe907b563481b7c06a21020467ee2c35a"
}
```

### Response from child device (no change)
Topic: `tedge/child01/commands/res/firmware_update`
a. Successful
```json
{
    "id": "1234",
    "status": "successful"
}
```
b. Failed
```json
{
    "id": "1234",
    "status": "failed",
    "reason" "because it's failed"
}
```
c. Executing
```json
{
    "id": "1234",
    "status": "executing"
}
```

### Output from plugin to outside
a. Successful
Topic: `tedge/child01/commands/firmware_update/done/successful`
```json
{
    "id": "1234",
    "status": "successful",
    "device": "child01",
    "name": "firmware",
    "url": "http://abc.com",
    "version": "0.1.0",
    "sha256": "e60d891f75e56177b7a4d375a65f2216c5dce4ee9c57468599fcdc2aaf446459"
}
```
b. Failed
Topic: `tedge/child01/commands/firmware_update/done/failed`
```json
{
    "id": "1234",
    "status": "failed",
    "device": "child01",
    "name": "firmware",
    "url": "http://abc.com",
    "version": "0.1.0",
    "sha256": "e60d891f75e56177b7a4d375a65f2216c5dce4ee9c57468599fcdc2aaf446459",
    "reason": "because it's failed"
}
```
c. Executing
Topic: `tedge/child01/commands/firmware_update/executing`
```json
{
    "id": "1234",
    "status": "executing",
    "device": "child01",
    "name": "firmware",
    "url": "http://abc.com",
    "version": "0.1.0",
    "sha256": "e60d891f75e56177b7a4d375a65f2216c5dce4ee9c57468599fcdc2aaf446459"
}
```